### PR TITLE
修复头像无法加载的问题

### DIFF
--- a/app/src/main/java/me/yluo/ruisiapp/App.java
+++ b/app/src/main/java/me/yluo/ruisiapp/App.java
@@ -42,8 +42,8 @@ public class App extends Application {
         // 自定义外网睿思服务器地址
         String customOutServerAddr = shp.getString("setting_rs_out_server_addr", App.BASE_URL_RS).trim();
         if (customOutServerAddr.length() > 0) {
-            if (!customOutServerAddr.startsWith("http://")) {
-                customOutServerAddr = "http://" + customOutServerAddr;
+            if (!customOutServerAddr.startsWith("https://")) {
+                customOutServerAddr = "https://" + customOutServerAddr;
             }
 
             if (!customOutServerAddr.endsWith("/")) {
@@ -97,7 +97,7 @@ public class App extends Application {
     public static final String POST_TID = "805203";
 
     //论坛基地址2个地址 第一个校园玩才能访问，第二个都可以
-    public static String BASE_URL_RS = "http://rs.xidian.edu.cn/";
+    public static String BASE_URL_RS = "https://rs.xidian.edu.cn/";
 
     //是否为校园网
     public static boolean IS_SCHOOL_NET = false;

--- a/app/src/main/java/me/yluo/ruisiapp/App.java
+++ b/app/src/main/java/me/yluo/ruisiapp/App.java
@@ -99,6 +99,9 @@ public class App extends Application {
     //论坛基地址2个地址 第一个校园玩才能访问，第二个都可以
     public static String BASE_URL_RS = "https://rs.xidian.edu.cn/";
 
+    //论坛部分独立 API 地址
+    public static String BASE_API_URL_RS = "https://rs-api.xidian.edu.cn/";
+
     //是否为校园网
     public static boolean IS_SCHOOL_NET = false;
 

--- a/app/src/main/java/me/yluo/ruisiapp/utils/UrlUtils.java
+++ b/app/src/main/java/me/yluo/ruisiapp/utils/UrlUtils.java
@@ -63,7 +63,7 @@ public class UrlUtils {
         if (urlUid.contains("uid")) {
             uid = GetId.getId("uid=", urlUid);
         }
-        return App.getBaseUrl() + "ucenter/avatar.php?uid=" + uid + "&size=small";
+        return App.BASE_API_URL_RS + "ucenter/avatar.php?uid=" + uid + "&size=small";
     }
 
     public static String getAvaterurlm(String urlUid) {
@@ -71,7 +71,7 @@ public class UrlUtils {
         if (urlUid.contains("uid")) {
             uid = GetId.getId("uid=", urlUid);
         }
-        return App.getBaseUrl() + "ucenter/avatar.php?uid=" + uid + "&size=middle";
+        return App.BASE_API_URL_RS + "ucenter/avatar.php?uid=" + uid + "&size=middle";
     }
 
     public static String getAvaterurlb(String urlUid) {
@@ -79,7 +79,7 @@ public class UrlUtils {
         if (urlUid.contains("uid")) {
             uid = GetId.getId("uid=", urlUid);
         }
-        return App.getBaseUrl() + "ucenter/avatar.php?uid=" + uid + "&size=big";
+        return App.BASE_API_URL_RS + "ucenter/avatar.php?uid=" + uid + "&size=big";
     }
 
     public static String getSignUrl() {


### PR DESCRIPTION
睿思在重构之后将头像迁移到了独立的 API 中，原有获取头像的方式已经不再适用。